### PR TITLE
Fix deployment ownership, label and object metadata

### DIFF
--- a/controllers/deployments/deployment_controller.go
+++ b/controllers/deployments/deployment_controller.go
@@ -88,6 +88,7 @@ func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			} else {
 				r.Logger.Error("unable to update", zap.String("object", object.Name))
 			}
+			return ctrl.Result{}, nil
 		}
 
 		return ctrl.Result{}, client.IgnoreNotFound(err)

--- a/pkg/kubetz/metadata.go
+++ b/pkg/kubetz/metadata.go
@@ -2,6 +2,7 @@ package kubetz
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func buildObjectMetadata(name, namespace string, ownerRef []metav1.OwnerReference) metav1.ObjectMeta {
@@ -10,4 +11,30 @@ func buildObjectMetadata(name, namespace string, ownerRef []metav1.OwnerReferenc
 		Namespace:       namespace,
 		OwnerReferences: ownerRef,
 	}
+}
+
+func buildMetadata(name, namespace, app, apiVersion, kind string, uid types.UID) metav1.ObjectMeta {
+	controlled := true
+	return metav1.ObjectMeta{
+		Name:      name,
+		Namespace: namespace,
+		Labels:    buildLabels(name, app),
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				APIVersion: apiVersion,
+				Kind:       kind,
+				Name:       name,
+				UID:        uid,
+				Controller: &controlled,
+			},
+		},
+	}
+}
+
+func buildLabels(name, app string) map[string]string {
+	m := make(map[string]string)
+	m["app"] = app
+	m["app.kubernetes.io/name"] = name
+	m["app.kubernetes.io/component"] = name
+	return m
 }


### PR DESCRIPTION
### Context
Deployments don't have metadata ownership so deleting a deployment won't recreate a new deployment instead.

Ownership reference needed in the object metadata as well as code refactor